### PR TITLE
Patch to skip Wipeout intro / fix for pixel-perfect window size

### DIFF
--- a/glrage/ContextImpl.cpp
+++ b/glrage/ContextImpl.cpp
@@ -297,6 +297,14 @@ void ContextImpl::setWindowSize(uint32_t width, uint32_t height) {
 
     SetWindowPos(m_hwnd, HWND_NOTOPMOST, left, top, width, height,
         SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+	
+	// resize again for pixel-perfect rendering (account for border/frame)
+	RECT cRect;
+	GetClientRect(m_hwnd, &cRect);
+	auto width1 = width + (width - cRect.right);
+	auto height1 = height + (height - cRect.bottom);
+	SetWindowPos(m_hwnd, HWND_NOTOPMOST, left, top, width1, height1,
+		SWP_SHOWWINDOW | SWP_FRAMECHANGED);
 }
 
 uint32_t ContextImpl::getWindowWidth() {

--- a/glrage/WipeoutPatcher.cpp
+++ b/glrage/WipeoutPatcher.cpp
@@ -37,6 +37,11 @@ void WipeoutPatcher::apply() {
     if (m_config.getBool("patch_disable_title_screen", false)) {
         patch(0x46B885, "E8 B8 40 00 00", "90 90 90 90 90");
     }
+	
+	// Disable introductory video.
+	if (m_config.getBool("patch_disable_introductory_video", false)) {
+		patch(0x46B808, "E8 33 46 00 00", "90 90 90 90 90");
+	}
 }
 
 BOOL WipeoutPatcher::hookSystemParametersInfoA(UINT uiAction, UINT uiParam, PVOID pvParam, UINT fWinIni) {

--- a/glrage/glrage.ini
+++ b/glrage/glrage.ini
@@ -123,3 +123,6 @@ patch_localization_locale = en_GB
 
 ; Disables unskippable title screen, which saves about 3 seconds of waiting.
 patch_disable_title_screen = false
+
+; Disables introductory video.
+patch_disable_introductory_video = false


### PR DESCRIPTION
Here's my first commit,

The patch to skip intro for Wipeout works fine for me, let me know otherwise.

The window resize improves things a bit, I went the 2nd SetWindowPos way to let the system do the heavy uplifting of handle borders & co ... works Ok for any resolution/full screen here.

Cheers !
